### PR TITLE
Fix: Add missing display-manager.nix dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738704702,
-        "narHash": "sha256-aq66AZxs/i4dJNpLF8gQbMg8BFjm92fXjzsuLr7JYYk=",
+        "lastModified": 1738741697,
+        "narHash": "sha256-F3/gglt0typLI/h4i+iXw9n6Y3ZZH42bx5riIU/6AsY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1e47f7101fedd857e561782d00d4cb1f6b69e7df",
+        "rev": "5997112695f3b02d3992764760fc6ddfef51fba3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,12 @@
     { self, nixpkgs, home-manager, sops-nix, nix-secrets, ghostty, ... }@inputs:
     let
       inherit (self) outputs;
-      forAllSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
       inherit (nixpkgs) lib;
       configVars = import ./vars { inherit inputs lib; };
       configLib = import ./lib { inherit lib; };

--- a/hosts/common/core/services/display-manager.nix
+++ b/hosts/common/core/services/display-manager.nix
@@ -1,3 +1,5 @@
+{ inputs, outputs, pkgs, lib, configLib, ... }:
+
 {
   systemd.services.display-manager.serviceConfig = {
     ProtectSystem = "full";
@@ -8,15 +10,8 @@
     PrivateIPC = true;
     RestrictSUIDSGID = true;
     RestrictRealtime = true;
-    RestrictNamespaces = [ 
-      "~cgroup" 
-    ];
-    RestrictAddressFamilies = [ 
-      "AF_UNIX"
-      "AF_NETLINK"
-      "AF_INET"
-      "AF_INET6"
-    ];
+    RestrictNamespaces = [ "~cgroup" ];
+    RestrictAddressFamilies = [ "AF_UNIX" "AF_NETLINK" "AF_INET" "AF_INET6" ];
     SystemCallErrorNumber = "EPERM";
     SystemCallFilter = [
       "~@obsolete"
@@ -30,9 +25,9 @@
     ];
     SystemCallArchitectures = "native";
     LockPersonality = true;
-    IPAddressDeny = ["0.0.0.0/0" "::/0"];
+    IPAddressDeny = [ "0.0.0.0/0" "::/0" ];
     CapabilityBoundingSet = [
-      "CAP_SYS_ADMIN" 
+      "CAP_SYS_ADMIN"
       "CAP_SETUID"
       "CAP_SETGID"
       "CAP_SETPCAP"
@@ -41,14 +36,14 @@
       "CAP_DAC_OVERRIDE"
       "CAP_DAC_READ_SEARCH"
       "CAP_FOWNER"
-      "CAP_IPC_OWNER" 
+      "CAP_IPC_OWNER"
       "CAP_FSETID"
       "CAP_SETFCAP"
       "CAP_CHOWN"
     ];
     DeviceAllow = "/dev/tty7 rw";
     DevicePolicy = "closed";
-    UMask = 0077;
+    UMask = 77;
     LogLevelMax = "debug";
     KeyringMode = lib.mkForce "private";
   };


### PR DESCRIPTION
lib.mkForce was being used, but the necessary top-level attributes to use were not present in the Nix file.